### PR TITLE
Rendering fixes, conflict with system Harfbuzz (added namespace)

### DIFF
--- a/externals/skia/configure.sh
+++ b/externals/skia/configure.sh
@@ -23,6 +23,14 @@ mkdir -p "$SRCLOC/upstream.original"
 	git fetch --depth=1 && \
 	git checkout $VERSION)
 
+# sync deps
+cd $SRCLOC/upstream.original/tools
+./git-sync-deps
+
+VERSION_HARFBUZZ="b37f03f" #2.8.1
+(cd $SRCLOC/upstream.original/third_party/externals/harfbuzz && \
+	git checkout $VERSION_HARFBUZZ)
+
 # Patch
 cp -rf $SRCLOC/upstream.original $SRCLOC/upstream.patched
 if [ -d $SRCLOC/patches ]; then
@@ -36,13 +44,7 @@ if [ -d $SRCLOC/patches ]; then
 	done
 fi
 
-# sync deps
-cd $SRCLOC/upstream.patched/tools
-./git-sync-deps
 
-VERSION_HARFBUZZ="b37f03f" #2.8.1
-(cd $SRCLOC/upstream.patched/third_party/externals/harfbuzz && \
-	git checkout $VERSION_HARFBUZZ)
 	
 #Patch jerror.c after git sync, before it is not available
 patch $SRCLOC/upstream.patched/third_party/externals/libjpeg-turbo/jerror.c $SRCLOC/patches/12-libjpeg-jerror.after_git_sync_patch

--- a/externals/skia/patches/1-SkFontHost_FreeType_common.patch
+++ b/externals/skia/patches/1-SkFontHost_FreeType_common.patch
@@ -1,5 +1,5 @@
---- upstream.original/src/ports/SkFontHost_FreeType_common.cpp	2021-06-16 13:17:29.000000000 +0300
-+++ /Users/macmini/OsmAnd/skia/src/ports/SkFontHost_FreeType_common.cpp	2021-06-15 11:29:20.000000000 +0300
+--- upstream.original/src/ports/SkFontHost_FreeType_common.cpp	2021-07-29 17:19:54.000000000 +0300
++++ upstream.patched/src/ports/SkFontHost_FreeType_common.cpp	2021-07-29 17:19:56.000000000 +0300
 @@ -760,8 +760,12 @@
      };
  };

--- a/externals/skia/patches/3-harfbuzz-ChainContextFormat.patch
+++ b/externals/skia/patches/3-harfbuzz-ChainContextFormat.patch
@@ -1,0 +1,82 @@
+--- upstream.original/third_party/externals/harfbuzz/src/hb-ot-layout-gsubgpos.hh	2021-08-02 14:37:11.000000000 +0300
++++ upstream.patched/third_party/externals/harfbuzz/src/hb-ot-layout-gsubgpos.hh	2021-08-02 15:04:36.000000000 +0300
+@@ -1777,6 +1777,7 @@
+ };
+ 
+ 
++namespace OsmAnd {
+ struct ContextFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -2267,6 +2268,7 @@
+   public:
+   DEFINE_SIZE_ARRAY (6, coverageZ);
+ };
++}
+ 
+ struct Context
+ {
+@@ -2286,9 +2288,9 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  ContextFormat1	format1;
+-  ContextFormat2	format2;
+-  ContextFormat3	format3;
++  OsmAnd::ContextFormat1	format1;
++  OsmAnd::ContextFormat2	format2;
++  OsmAnd::ContextFormat3	format3;
+   } u;
+ };
+ 
+@@ -2746,6 +2748,7 @@
+   DEFINE_SIZE_ARRAY (2, rule);
+ };
+ 
++namespace OsmAnd {
+ struct ChainContextFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -3349,6 +3352,7 @@
+   public:
+   DEFINE_SIZE_MIN (10);
+ };
++}
+ 
+ struct ChainContext
+ {
+@@ -3368,13 +3372,13 @@
+   protected:
+   union {
+   HBUINT16		format;	/* Format identifier */
+-  ChainContextFormat1	format1;
+-  ChainContextFormat2	format2;
+-  ChainContextFormat3	format3;
++  OsmAnd::ChainContextFormat1	format1;
++  OsmAnd::ChainContextFormat2	format2;
++  OsmAnd::ChainContextFormat3	format3;
+   } u;
+ };
+ 
+-
++namespace OsmAnd {
+ template <typename T>
+ struct ExtensionFormat1
+ {
+@@ -3431,6 +3435,7 @@
+   public:
+   DEFINE_SIZE_STATIC (8);
+ };
++}
+ 
+ template <typename T>
+ struct Extension
+@@ -3477,7 +3482,7 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  ExtensionFormat1<T>	format1;
++  OsmAnd::ExtensionFormat1<T>	format1;
+   } u;
+ };
+ 

--- a/externals/skia/patches/4-harfbuzz-SingleSubstFormat.patch
+++ b/externals/skia/patches/4-harfbuzz-SingleSubstFormat.patch
@@ -1,0 +1,131 @@
+--- upstream.original/third_party/externals/harfbuzz/src/hb-ot-layout-gsub-table.hh	2021-08-02 14:37:11.000000000 +0300
++++ upstream.patched/third_party/externals/harfbuzz/src/hb-ot-layout-gsub-table.hh	2021-08-02 15:02:19.000000000 +0300
+@@ -40,7 +40,7 @@
+ static void SingleSubst_serialize (hb_serialize_context_t *c,
+ 				   Iterator it);
+ 
+-
++namespace OsmAnd {
+ struct SingleSubstFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -251,6 +251,7 @@
+   public:
+   DEFINE_SIZE_ARRAY (6, substitute);
+ };
++}
+ 
+ struct SingleSubst
+ {
+@@ -299,8 +300,8 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  SingleSubstFormat1	format1;
+-  SingleSubstFormat2	format2;
++  OsmAnd::SingleSubstFormat1	format1;
++  OsmAnd::SingleSubstFormat2	format2;
+   } u;
+ };
+ 
+@@ -392,6 +393,7 @@
+   DEFINE_SIZE_ARRAY (2, substitute);
+ };
+ 
++namespace OsmAnd {
+ struct MultipleSubstFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -497,6 +499,7 @@
+   public:
+   DEFINE_SIZE_ARRAY (6, sequence);
+ };
++}
+ 
+ struct MultipleSubst
+ {
+@@ -529,7 +532,7 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  MultipleSubstFormat1	format1;
++  OsmAnd::MultipleSubstFormat1	format1;
+   } u;
+ };
+ 
+@@ -623,6 +626,7 @@
+   DEFINE_SIZE_ARRAY (2, alternates);
+ };
+ 
++namespace OsmAnd {
+ struct AlternateSubstFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -736,6 +740,7 @@
+   public:
+   DEFINE_SIZE_ARRAY (6, alternateSet);
+ };
++}
+ 
+ struct AlternateSubst
+ {
+@@ -768,7 +773,7 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  AlternateSubstFormat1	format1;
++  OsmAnd::AlternateSubstFormat1	format1;
+   } u;
+ };
+ 
+@@ -989,6 +994,7 @@
+   DEFINE_SIZE_ARRAY (2, ligature);
+ };
+ 
++namespace OsmAnd {
+ struct LigatureSubstFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -1116,6 +1122,7 @@
+   public:
+   DEFINE_SIZE_ARRAY (6, ligatureSet);
+ };
++}
+ 
+ struct LigatureSubst
+ {
+@@ -1155,7 +1162,7 @@
+   protected:
+   union {
+   HBUINT16		format;		/* Format identifier */
+-  LigatureSubstFormat1	format1;
++  OsmAnd::LigatureSubstFormat1	format1;
+   } u;
+ };
+ 
+@@ -1170,7 +1177,7 @@
+   bool is_reverse () const;
+ };
+ 
+-
++namespace OsmAnd {
+ struct ReverseChainSingleSubstFormat1
+ {
+   bool intersects (const hb_set_t *glyphs) const
+@@ -1381,6 +1388,7 @@
+   public:
+   DEFINE_SIZE_MIN (10);
+ };
++}
+ 
+ struct ReverseChainSingleSubst
+ {
+@@ -1398,7 +1406,7 @@
+   protected:
+   union {
+   HBUINT16				format;		/* Format identifier */
+-  ReverseChainSingleSubstFormat1	format1;
++  OsmAnd::ReverseChainSingleSubstFormat1	format1;
+   } u;
+ };
+ 

--- a/native/src/commonRendering.h
+++ b/native/src/commonRendering.h
@@ -7,7 +7,7 @@
 #include <SkTypeface.h>
 #include <SkFont.h>
 #include <SkFontMgr.h>
-#include <hb-ot.h>
+#include "hb-ot.h"
 #include <assert.h>
 
 #include "CommonCollections.h"

--- a/native/src/textdraw.cpp
+++ b/native/src/textdraw.cpp
@@ -12,7 +12,7 @@
 #include <SkFontPriv.h>
 #include <SkAutoMalloc.h>
 #include <SkTextBlob.h>
-#include <hb-ot.h>
+#include "hb-ot.h"
 #include <math.h>
 #include <time.h>
 

--- a/targets/.cmake/CMakeLists.txt
+++ b/targets/.cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.7 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.0.0 FATAL_ERROR)
 project(osmand_core_legacy)
 set(OSMAND_ROOT "${CMAKE_CURRENT_LIST_DIR}/../..")
 set(OSMAND_PROJECTS_ROOT "${CMAKE_CURRENT_LIST_DIR}/projects")
@@ -34,6 +34,9 @@ if(CMAKE_CXX_COMPILER_FLAGS)
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_COMPILER_FLAGS}")
 endif()
 
+#set(CMAKE_IGNORE_PATH "/usr/local/lib")
+link_directories("${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+
 # External : z
 add_subdirectory("${OSMAND_PROJECTS_ROOT}/zlib" "zlib")
 
@@ -65,4 +68,4 @@ add_dependencies(skia_osmand png_osmand jpeg_osmand expat_osmand)
 
 # OsmAnd core
 add_subdirectory("${OSMAND_PROJECTS_ROOT}/OsmAndCore" "OsmAndCore")
-add_dependencies(osmand	skia_osmand protobuf_osmand harfbuzz)
+add_dependencies(osmand	skia_osmand protobuf_osmand)

--- a/targets/.cmake/projects/OsmAndCore/CMakeLists.txt
+++ b/targets/.cmake/projects/OsmAndCore/CMakeLists.txt
@@ -22,7 +22,7 @@ include_directories(AFTER SYSTEM
 	#"${OSMAND_ROOT}/externals/giflib/upstream.patched/lib"
 	"${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/externals/libjpeg-turbo"
 	"${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/libpng"
-	#"${OSMAND_ROOT}/externals/harfbuzz/upstream.patched/src"
+	"${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/externals/harfbuzz/src"
 	"${OSMAND_ROOT}/externals/protobuf/upstream.patched/src"
 	"${OSMAND_ROOT}/native/include"
 	"${OSMAND_ROOT}/native/src"
@@ -106,5 +106,5 @@ add_library(osmand SHARED
 target_link_libraries(osmand LINK_PUBLIC
 	skia_osmand
 	protobuf_osmand
-	harfbuzz
+	harfbuzz_osmand
 )

--- a/targets/.cmake/projects/freetype/CMakeLists.txt
+++ b/targets/.cmake/projects/freetype/CMakeLists.txt
@@ -1,7 +1,5 @@
 project(freetype2_osmand)
 
-# NOT USED ANYMORE  !!!!
-
 set(ROOT "${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/externals/freetype")
 
 set(UPSTREAM "${ROOT}")
@@ -57,8 +55,6 @@ add_library(freetype2_osmand STATIC
 	"${UPSTREAM}/src/type1/t1afm.c"
 )
 
-if(CMAKE_TARGET_OS STREQUAL "linux")
-	target_link_libraries(freetype2_osmand LINK_PUBLIC
-		png
-	)
-endif()
+target_link_libraries(freetype2_osmand LINK_PUBLIC
+	png_osmand
+)

--- a/targets/.cmake/projects/harfbuzz/CMakeLists.txt
+++ b/targets/.cmake/projects/harfbuzz/CMakeLists.txt
@@ -1,9 +1,21 @@
 project(harfbuzz_osmand)
-set(SKIP_INSTALL_ALL ON)
 
 if(CMAKE_COMPILER_FAMILY STREQUAL "gcc" OR CMAKE_COMPILER_FAMILY STREQUAL "clang")
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
 	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 endif()
 
-add_subdirectory("${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/externals/harfbuzz" "harfbuzz")
+if(CMAKE_TARGET_OS STREQUAL "linux")
+	set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-threadsafe-statics")
+endif()
+
+set(HARFBUZZ_ROOT "${OSMAND_ROOT}/externals/skia/upstream.patched/third_party/externals/harfbuzz")
+
+set(UPSTREAM "${HARFBUZZ_ROOT}")
+include_directories(AFTER SYSTEM
+	"${UPSTREAM}/src"
+)
+
+add_library(harfbuzz_osmand STATIC
+	"${UPSTREAM}/src/harfbuzz.cc"
+)

--- a/targets/.cmake/projects/skia/CMakeLists.txt
+++ b/targets/.cmake/projects/skia/CMakeLists.txt
@@ -168,14 +168,15 @@ add_library(skia_osmand STATIC
 	${target_specific_sources}
 )
 
-find_package(Freetype REQUIRED)
+#find_package(Freetype REQUIRED)
 target_link_libraries(skia_osmand LINK_PUBLIC
 	expat_osmand
 	png_osmand
 	jpeg_osmand
-	${FREETYPE_LIBRARIES}
+	freetype2_osmand
 )
-target_include_directories(skia_osmand PRIVATE ${FREETYPE_INCLUDE_DIRS})
+#${FREETYPE_LIBRARIES}
+#target_include_directories(skia_osmand PRIVATE ${FREETYPE_INCLUDE_DIRS})
 	
 if(CMAKE_TARGET_OS STREQUAL "linux")
 	find_library(FONTCONFIG_LIBRARY fontconfig)


### PR DESCRIPTION
Conflict with system Harfbuzz:
Rename static lib harfbuzz to harfbuzz_osmand
Add patches with OsmAnd namespace for avoid conflict with system Harfbuzz
Change #include from system prefer (<>) to local ("")

Rendering fixes:
Text on path, changed highlight function (SkPaint::kStroke_Style to SkImageFilters::Dilate).
Text on path, compressed by x axis on 1.05 for avoid oferflow rendering field.

Other:
Using local Freetype library instead system