### PR TITLE
backward maxspeed fix

### DIFF
--- a/native/src/binaryRead.h
+++ b/native/src/binaryRead.h
@@ -540,13 +540,13 @@ struct RouteDataObject {
 		for (int type : types) {
 			RouteTypeRule r = region->quickGetEncodingRule(type);
 			bool forwardDirection = r.isForward() >= 0;
-			if (forwardDirection == direction) {
+			if ((direction && r.isForward() == 1) ||
+				(!direction && r.isForward() == -1) ||
+				r.isForward() == 0) {
 				// priority over default
 				maxSpeed = r.maxSpeed(RouteTypeRule::PROFILE_NONE) > 0 ? r.maxSpeed(RouteTypeRule::PROFILE_NONE) : maxSpeed;
 				maxProfileSpeed = r.maxSpeed(profile) > 0 ? r.maxSpeed(profile) : maxProfileSpeed;
-            } else if (r.maxSpeed(RouteTypeRule::PROFILE_NONE) > 0) {
-                maxSpeed = r.maxSpeed(RouteTypeRule::PROFILE_NONE);
-            }
+			}
 		}
 		return maxProfileSpeed > 0 ? maxProfileSpeed : maxSpeed;
 	}

--- a/native/src/binaryRead.h
+++ b/native/src/binaryRead.h
@@ -544,7 +544,9 @@ struct RouteDataObject {
 				// priority over default
 				maxSpeed = r.maxSpeed(RouteTypeRule::PROFILE_NONE) > 0 ? r.maxSpeed(RouteTypeRule::PROFILE_NONE) : maxSpeed;
 				maxProfileSpeed = r.maxSpeed(profile) > 0 ? r.maxSpeed(profile) : maxProfileSpeed;
-			}
+            } else if (r.maxSpeed(RouteTypeRule::PROFILE_NONE) > 0) {
+                maxSpeed = r.maxSpeed(RouteTypeRule::PROFILE_NONE);
+            }
 		}
 		return maxProfileSpeed > 0 ? maxProfileSpeed : maxSpeed;
 	}


### PR DESCRIPTION
[Issue](https://github.com/osmandapp/OsmAnd-iOS/issues/2921)

Before. No backward maxspeer

<img width="300" src="https://github.com/osmandapp/OsmAnd-core-legacy/assets/35684515/d0e7b7e9-d397-4ca0-9109-89e54a79ac95"> <img width="300" src="https://github.com/osmandapp/OsmAnd-core-legacy/assets/35684515/b758c921-66ba-4859-a2ec-3b8349e3b92f">

After. Forward and backward maxspeed

<img width="300" src="https://github.com/osmandapp/OsmAnd-core-legacy/assets/35684515/fa2820c5-4832-496c-9843-f2d84b5323b1"> <img width="300" src="https://github.com/osmandapp/OsmAnd-core-legacy/assets/35684515/2a4d5c70-4695-4ca6-aeeb-38adafb9b686">

Restored line 539 for default case.

<img width="300" alt="Screenshot 2023-07-06 at 16 28 24" src="https://github.com/osmandapp/OsmAnd-core-legacy/assets/35684515/8472c94a-10f6-4dfd-953a-89866463efeb">

P.S.: Android has this bug too.