### PR TITLE
Bicycle routing. Fix recalculation

### DIFF
--- a/native/src/hhRouteDataStructure.cpp
+++ b/native/src/hhRouteDataStructure.cpp
@@ -53,7 +53,7 @@ NetworkDBSegment * NetworkDBPoint::getSegment(const NetworkDBPoint * target, boo
     return nullptr;
 }
 
-void HHRoutingContext::clearVisited(UNORDERED_map<int64_t, NetworkDBPoint *> & stPoints, UNORDERED_map<int64_t, NetworkDBPoint *> & endPoints) {
+void HHRoutingContext::clearVisited(const UNORDERED_map<int64_t, NetworkDBPoint *> & stPoints, const UNORDERED_map<int64_t, NetworkDBPoint *> & endPoints) {
     resetAllQueues();
     for (NetworkDBPoint * p : queueAdded) {
         SHARED_PTR<RouteSegment> pos = std::move(p->rt(false)->rtDetailedRoute);
@@ -64,7 +64,8 @@ void HHRoutingContext::clearVisited(UNORDERED_map<int64_t, NetworkDBPoint *> & s
         if (itS != stPoints.end() && pos) {
             p->setDistanceToEnd(false, distanceToEnd(false, p));
             p->setDetailedParentRt(false, pos);
-        } else if (itE != endPoints.end() && rev) {
+        }
+        if (itE != endPoints.end() && rev) {
             p->setDistanceToEnd(true, distanceToEnd(true, p));
             p->setDetailedParentRt(true, rev);
         }

--- a/native/src/hhRouteDataStructure.h
+++ b/native/src/hhRouteDataStructure.h
@@ -532,7 +532,7 @@ struct HHRoutingContext {
         while( !queueRev->empty() ) queueRev->pop();
     }
     
-    void clearVisited(UNORDERED_map<int64_t, NetworkDBPoint *> & stPoints, UNORDERED_map<int64_t, NetworkDBPoint *> & endPoints);
+    void clearVisited(const UNORDERED_map<int64_t, NetworkDBPoint *> & stPoints, const UNORDERED_map<int64_t, NetworkDBPoint *> & endPoints);
     
     UNORDERED_map<int64_t, NetworkDBPoint *> loadNetworkPoints() {
 


### PR DESCRIPTION
Fix route ```start=49.808346,31.787925&finish=49.456382,32.021975&profile=bicycle```

To issue https://github.com/osmandapp/OsmAnd-Issues/issues/2412#issuecomment-1936308229