### PR TITLE
Fix reiteration start/end points for HH routing

### DIFF
--- a/native/src/hhRoutePlanner.cpp
+++ b/native/src/hhRoutePlanner.cpp
@@ -454,8 +454,8 @@ void HHRoutePlanner::findFirstLastSegments(const SHARED_PTR<HHRoutingContext> & 
         OsmAnd::LogPrintf(OsmAnd::LogSeverityLevel::Warning, "End point was not found (hhRoutePlanner) [Native]");
         return;
     }
-    auto & stOthers = startPnt->others;
-    auto & endOthers = endPnt->others;
+    vector<SHARED_PTR<RouteSegmentPoint>> stOthers = startPnt->others;//copy
+    vector<SHARED_PTR<RouteSegmentPoint>> endOthers = endPnt->others;
     do {
         if (startReiterate + endReiterate >= hctx->config->MAX_START_END_REITERATIONS) {
             break;


### PR DESCRIPTION
To issue https://github.com/osmandapp/OsmAnd-Issues/issues/2412#issuecomment-1936308229
(HH-cpp failed) UA start=48.03523,38.16657&finish=48.02013,37.82119&profile=car