### PR TITLE
Fix build for externals/proj (std::int64_t error)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore all externals upstream files
 /externals/**/upstream.*
+externals/**/.stamp
 externals/.stamp
 .gradle
 # Ignore binary files

--- a/externals/proj/patches/0-fix-build-int64_t.patch
+++ b/externals/proj/patches/0-fix-build-int64_t.patch
@@ -1,0 +1,22 @@
+diff -rupN upstream.original/src/projections/s2.cpp upstream.patched/src/projections/s2.cpp
+--- upstream.original/src/projections/s2.cpp	2024-10-29 20:41:27.304326170 +0100
++++ upstream.patched/src/projections/s2.cpp	2024-10-29 20:55:38.490959279 +0100
+@@ -52,6 +52,7 @@
+ 
+ #include <errno.h>
+ #include <cmath>
++#include <cstdint> // for int64_t and uint64_t
+ 
+ #include "proj.h"
+ #include "proj_internal.h"
+diff -rupN upstream.original/src/proj_json_streaming_writer.hpp upstream.patched/src/proj_json_streaming_writer.hpp
+--- upstream.original/src/proj_json_streaming_writer.hpp	2024-10-29 20:41:27.304326170 +0100
++++ upstream.patched/src/proj_json_streaming_writer.hpp	2024-10-29 20:55:04.607627282 +0100
+@@ -33,6 +33,7 @@
+ 
+ #include <vector>
+ #include <string>
++#include <cstdint> // for int64_t and uint64_t
+ 
+ #define CPL_DLL
+ 

--- a/native/src/hhRoutePlanner.cpp
+++ b/native/src/hhRoutePlanner.cpp
@@ -722,8 +722,8 @@ void HHRoutePlanner::recalculateNetworkCluster(const SHARED_PTR<HHRoutingContext
 	SHARED_PTR<RouteSegmentPoint> s = loadPoint(hctx->rctx, start);
 	if (s == nullptr) {
 		OsmAnd::LogPrintf(OsmAnd::LogSeverityLevel::Warning,
-		                  "HH recalculateNetworkCluster: loadPoint() is NULL for Point %d (%d %d-%d)",
-		                  start->index, start->roadId / 64, start->start, start->end);
+		                  "HH recalculateNetworkCluster: loadPoint() is NULL for Point %u (%u %d-%d)",
+		                  (unsigned int)(start->index), (unsigned int)(start->roadId / 64), start->start, start->end);
 		return;
 	}
 	//hctx->rctx->progress = std::make_shared<RouteCalculationProgress>(); // we should reuse same progress for cancellation


### PR DESCRIPTION
```
externals/proj/upstream.patched/src/proj_json_streaming_writer.hpp:42:9: error: no type named 'int64_t' in namespace 'std'; did you mean simply 'int64_t'?
externals/proj/upstream.patched/src/proj_json_streaming_writer.hpp:43:9: error: no type named 'uint64_t' in namespace 'std'; did you mean simply 'uint64_t'?
```