### PR TITLE
Fix awkward "X (X)" when name == ref (rendering)

### DIFF
--- a/native/src/rendering.cpp
+++ b/native/src/rendering.cpp
@@ -382,7 +382,11 @@ void renderText(MapDataObject* obj, RenderableObject* rObj, RenderingRuleSearchR
 				if (tagName2 != "") {
 					std::string tv = obj->objectNames[tagName2];
 					if (tv != "") {
-						info->text = name + " (" + tv + ")";
+						if (name != tv) {
+							info->text = name + " (" + tv + ")";
+						} else {
+							info->text = name; // avoid awkward "$X ($X)"
+						}
 					}
 				}
 				info->drawOnPath = (path != NULL) && (req->getIntPropertyValue(req->props()->R_TEXT_ON_PATH, 0) > 0);


### PR DESCRIPTION
v1-cpp rendering fix.

It fixes duplicated text on the path when `name` == `ref` in the data.

For instance, https://www.openstreetmap.org/way/47809137 was shown as "14A (14A)".
