### PR TITLE
sync Fix turn lanes 24867

### DIFF
--- a/native/src/routeResultPreparation.cpp
+++ b/native/src/routeResultPreparation.cpp
@@ -1086,9 +1086,6 @@ SHARED_PTR<TurnType> getTurnByCurrentTurns(std::vector<SHARED_PTR<AttachedRoadIn
 	for (auto const& ln : rawLanes) {
 		TurnType::collectTurnTypes(ln, currentTurns);
 	}
-
-	// Here we detect single case when turn lane continues on 1 road / single sign and all other lane turns continue on
-	// the other side roads
     vector<int> analyzedList(currentTurns.begin(), currentTurns.end());
     if (analyzedList.size() > 1) {
         if (keepTurnType == TurnType::KL) {
@@ -1098,6 +1095,7 @@ SHARED_PTR<TurnType> getTurnByCurrentTurns(std::vector<SHARED_PTR<AttachedRoadIn
             // no need analyze turns in right side (current direction)
             analyzedList.erase(analyzedList.end() - 1);
         }
+        // Here we detect single case when turn lane continues on 1 road / single sign and all other lane turns continue on the other side roads
         if (containsAll(analyzedList, otherSideTurns)) {
             // currentTurns.removeAll(otherSideTurns);
             for (int i : otherSideTurns) {
@@ -1107,7 +1105,15 @@ SHARED_PTR<TurnType> getTurnByCurrentTurns(std::vector<SHARED_PTR<AttachedRoadIn
                 }
             }
             if (currentTurns.size() == 1) {
-                return TurnType::ptrValueOf(*currentTurns.begin(), leftSide);
+                
+                int detectedTurn = currentTurns.front();
+                if (keepTurnType == TurnType::KR && TurnType::isLeftTurn(detectedTurn)) {
+                    return TurnType::ptrValueOf(keepTurnType, leftSide);
+                }
+                if (keepTurnType == TurnType::KL && TurnType::isRightTurn(detectedTurn)) {
+                    return TurnType::ptrValueOf(keepTurnType, leftSide);
+                }
+                return TurnType::ptrValueOf(detectedTurn, leftSide);
             }
         } else {
             // Avoid "keep" instruction if active side contains only "through" moving


### PR DESCRIPTION
[issue](https://github.com/osmandapp/OsmAnd/issues/23787)

[synced this android commit](https://github.com/osmandapp/OsmAnd/pull/24867/changes)

[testing route](https://osmand.net/map/navigate/?start=3.133840,101.756150&end=3.133880,101.766010&profile=motorcycle#17/3.13301/101.75902)

Before (turn left - wrong):

<img width="300" alt="508712561-a368536d-53fc-4436-af55-4c01ba22d531" src="https://github.com/user-attachments/assets/18330d97-c8e9-484f-a405-f299b0c28771" />


<img width="300" alt="Screenshot 2026-05-21 at 00 02 08" src="https://github.com/user-attachments/assets/4478e5ac-6c9f-4664-bc83-8a07285582a7" />

---

After

<img width="951" height="954" alt="Screenshot 2026-05-21 at 17 43 19" src="https://github.com/user-attachments/assets/1812b224-5b51-4e1a-9f9f-87b38c362755" />

---

<img width="1727" height="693" alt="Screenshot 2026-06-01 at 22 43 23" src="https://github.com/user-attachments/assets/8497c086-385e-4f16-921b-8d9618256e83" />
